### PR TITLE
correct realsense package names

### DIFF
--- a/src/sim/moonbot_isaac/package.xml
+++ b/src/sim/moonbot_isaac/package.xml
@@ -7,8 +7,8 @@
   <maintainer email="azazdeaz@gmail.com">artefacts</maintainer>
   <license>TODO: License declaration</license>
 
-  <depend>realsense2-camera-msgs</depend>
-  <depend>realsense2-description</depend>
+  <depend>realsense2_camera_msgs</depend>
+  <depend>realsense2_description</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
I was getting "unable to find" errors with rosdep install, this should update and fix

cc @azazdeaz @fabid 