### PR TITLE
rosdep install non-interactive

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -308,7 +308,7 @@ def task_rosdep():
     yield {
         "name": "install",
         "actions": [
-            f"{ros_src_cmd}rosdep install --from-paths src --ignore-src -r",
+            f"{ros_src_cmd}rosdep install --from-paths src --ignore-src -r -y",
         ],
         "task_dep": ["rosdep:init", "rosdep:update"]
         + [f"rosdep:{apt_pkg}" for apt_pkg in missing_rosdep],


### PR DESCRIPTION
lets make rosdep install non-interactive as well.

This is particulary useful when other folks add their packages to the src folder so that everything can be built at once with dodo (instead of building and sourcing two different packages)

cc @azazdeaz @fabid 