### PR TITLE
add transform -> scale

### DIFF
--- a/src/sim/moonbot_isaac/config.md
+++ b/src/sim/moonbot_isaac/config.md
@@ -98,14 +98,14 @@ parse_mimic_joints = false
 without_controls = false
 publish_ground_truth_tf = true
 [robot.transform]
-translation = [0, 0, 0.1]
-rotation = [1, 0, 0, 0]
+translation = [0.0, 0.0, 0.1]
+rotation = [1.0, 0.0, 0.0, 0.0]
 [robot.initial_joint_positions]
 joint1 = 1.57  # radians
-joint2 = { value = 90, degree = true }  # degrees converted to radians
+joint2 = { value = 90.0, degree = true }  # degrees converted to radians
 [robot.realsense_camera]
-width = 640
-height = 480
+width = 640.0
+height = 480.0
 
 [[robot]]
 name = "robot2"
@@ -114,15 +114,15 @@ visualization_mode = true
 
 [ground]
 [ground.transform]
-translation = [0, 0, 0]
-rotation = [1, 0, 0, 0]
+translation = [0.0, 0.0, 0.0]
+rotation = [1.0, 0.0, 0.0, 0.0]
 
 [camera]
 translation = [-0.3577958949555765, -1.1875695366976564, 0.632201840815314]
 target = [0.4, 0.4, 0.0]
 
 [light]
-intensity = 1000
+intensity = 1000.0
 
 [[observer_camera]]
 node_namespace = "observer_camera1"
@@ -138,8 +138,8 @@ name = "environment"
 kinematic = true
 approximation_shape = "meshSimplification"
 [usd_reference.transform]
-translation = [0, 0, 0]
-rotation = [0, 0, 0, 1]
+translation = [0.0, 0.0, 0.0]
+rotation = [0.0, 0.0, 0.0, 1.0]
 [usd_reference.prim_properties]
 "some/prim/path.attribute" = "value"
 

--- a/src/sim/moonbot_isaac/environments/config.py
+++ b/src/sim/moonbot_isaac/environments/config.py
@@ -21,8 +21,8 @@ class CameraConfig(BaseModel):
     target: List[float] = Field(default_factory=lambda: [0.4, 0.4, 0.0])
 
 
-class LightConfig(BaseModel):
-    intensity: float = 1000
+# class LightConfig(BaseModel):
+#     intensity: float = 1000
 
 
 class TransformConfig(BaseModel):
@@ -170,7 +170,7 @@ class SimConfig(BaseModel):
     observer_cameras: List[ObserverCameraConfig] = Field(default_factory=list)
     ground: GroundPlaneConfig = Field(default_factory=GroundPlaneConfig)
     camera: CameraConfig = Field(default_factory=CameraConfig)
-    light: LightConfig = Field(default_factory=LightConfig)
+    # light: LightConfig = Field(default_factory=LightConfig)
     usd_references: List[UsdReferenceConfig] = Field(default_factory=list)
 
 

--- a/src/sim/moonbot_isaac/environments/config.py
+++ b/src/sim/moonbot_isaac/environments/config.py
@@ -28,6 +28,7 @@ class LightConfig(BaseModel):
 class TransformConfig(BaseModel):
     translation: List[float] = Field(default_factory=lambda: [0, 0, 0])
     rotation: List[float] = Field(default_factory=lambda: [1, 0, 0, 0])
+    scale: List[float] = Field(default_factory=lambda: [1.0, 1.0, 1.0])
 
 
 class JointPositionDetail(BaseModel):

--- a/src/sim/moonbot_isaac/environments/isaac_utils.py
+++ b/src/sim/moonbot_isaac/environments/isaac_utils.py
@@ -60,6 +60,11 @@ def apply_transform_config(prim, transform: TransformConfig):
             pxr.UsdGeom.XformOp.TypeOrient, pxr.UsdGeom.XformOp.PrecisionDouble, ""
         )
 
+    if "xformOp:scale" not in prop_names:
+        xformable.AddXformOp(
+            pxr.UsdGeom.XformOp.TypeScale, pxr.UsdGeom.XformOp.PrecisionDouble, ""
+        )
+
     set_attr_cmd(
         prim,
         "xformOp:translate",
@@ -77,6 +82,15 @@ def apply_transform_config(prim, transform: TransformConfig):
             transform.rotation[1],
             transform.rotation[2],
             transform.rotation[3],
+        ),
+    )
+    set_attr_cmd(
+        prim,
+        "xformOp:scale",
+        Gf.Vec3f(
+            transform.scale[0],
+            transform.scale[1],
+            transform.scale[2],
         ),
     )
 

--- a/src/sim/moonbot_isaac/environments/robot_definition_reader.py
+++ b/src/sim/moonbot_isaac/environments/robot_definition_reader.py
@@ -198,17 +198,19 @@ class RobotDefinitionReader:
         while True:
             try:
                 robot_description = self.get_robot_description()
+
+                self.urdf_doc = robot_description
+                self.urdf_description, self.urdf_extras = process_robot_description(
+                    robot_description, self.robot_config.name
+                )
+                self.on_description_received(self.urdf_description)
+                
                 break
             except Exception as e:
                 logging.error(
                     f"Error while getting robot description: {e}. \n\nTrying again...\n\n"
                 )
                 time.sleep(1.0)
-        self.urdf_doc = robot_description
-        self.urdf_description, self.urdf_extras = process_robot_description(
-            robot_description, self.robot_config.name
-        )
-        self.on_description_received(self.urdf_description)
 
     def start_get_robot_description(self):
         thread = threading.Thread(target=self.service_call)

--- a/src/sim/moonbot_isaac/environments/run_sim.py
+++ b/src/sim/moonbot_isaac/environments/run_sim.py
@@ -47,8 +47,7 @@ import omni.kit.commands
 from omni.isaac.core import World
 from omni.isaac.core.utils.stage import add_reference_to_stage
 from omni.kit.viewport.utility.camera_state import ViewportCameraState
-from pxr import Gf, Sdf, UsdLux
-
+from pxr import Gf, Sdf, UsdLux, UsdGeom
 
 def reference_usd(usd_file: str, prim_path: str):
     path = str(Path(__file__).parent / "usd" / usd_file)
@@ -88,6 +87,10 @@ if config.ground:
     ground = reference_usd("ground.usda", "/Ground")
     if config.ground.transform:
         apply_transform_config(ground, config.ground.transform)
+    # We dont want the ground plane default sphere light
+    sphere_light = world.stage.GetPrimAtPath("/Ground/defaultGroundPlane/SphereLight")
+    if sphere_light.IsValid():
+        sphere_light.GetAttribute("visibility").Set("invisible")
 
 for observer_camera_config in config.observer_cameras:
     ObserverCamera(observer_camera_config).initialize()
@@ -101,16 +104,34 @@ camera_state.set_position_world(
 )
 camera_state.set_target_world(Gf.Vec3d(*config.camera.target), True)
 
-distantLight = UsdLux.DistantLight.Define(world.stage, Sdf.Path("/DistantLight"))
-distantLight.CreateIntensityAttr(500)
-
 omni.kit.commands.execute(
     "CreatePrimWithDefaultXform",
     prim_type="DomeLight",
     prim_path="/World/DomeLight",
-    attributes={"inputs:intensity": 1000, "inputs:texture:format": "latlong"},
-    select_new_prim=True,
+    attributes={
+        "inputs:colorTemperature": 6150,
+        "inputs:intensity": 1,
+        "inputs:exposure": 8,
+        "inputs:texture:format": "latlong",
+    },
+    select_new_prim=False,
 )
+dome_light = world.stage.GetPrimAtPath("/World/DomeLight")
+dome_light.CreateAttribute("visibleInPrimaryRay", Sdf.ValueTypeNames.Bool).Set(False)
+# Create DistantLight with specified settings
+distantLight = UsdLux.DistantLight.Define(world.stage, Sdf.Path("/DistantLight"))
+distantLight.CreateColorTemperatureAttr(7250)
+distantLight.CreateIntensityAttr(1.5)
+distantLight.CreateExposureAttr(9.5)
+distantLight.CreateAngleAttr(0.53)
+
+# Set transform for distant light (translate and rotate)
+xform = UsdGeom.Xformable(distantLight)
+xform.ClearXformOpOrder()
+# Translation
+xform.AddTranslateOp().Set(Gf.Vec3d(0, 0, 305))
+# Rotation (55, 0, 135 degrees)
+xform.AddRotateXYZOp().Set(Gf.Vec3f(55, 0, 135))
 
 
 def set_initial_joint_positions():


### PR DESCRIPTION
The PR allows the "scale" property to be set on usd references.

Current use case is to flatten a surface when you are running a test which requires a flat plane -> whether it be with collisions on, or off (and you just need it to look like nothing is clipping through ther world)